### PR TITLE
Fix for the broken cutscene panels post v28

### DIFF
--- a/source/fixes.ixx
+++ b/source/fixes.ixx
@@ -1,0 +1,27 @@
+module;
+
+#include <common.hxx>
+
+export module fixes;
+import common;
+
+class Fixes
+{
+public:
+    Fixes()
+    {
+        FusionFix::onInitEventAsync() += []()
+            {
+                auto pattern = hook::pattern("F3 0F 59 CC F3 0F 59 C4 F3 0F 59 DC");
+
+                // for the renderer command 0xB6 both v22 and console sample around the center
+                // whereas v28 and above on PC calculate the sampling center from the coords which breaks panels
+                injector::MakeNOP(pattern.get_first(), 8, true);
+                static auto FixCutscenePanels = safetyhook::create_mid(pattern.get_first(), [](SafetyHookContext& regs)
+                    {
+                        regs.xmm1 = regs.xmm4;
+                        regs.xmm0 = regs.xmm4;
+                    });
+            };
+    }
+} Fixes;


### PR DESCRIPTION
Makes the game sample the center like old versions and console which fixes the panels

| Before| After|
|-----------------------------|-----------------------------|
| <img width="1920" height="1080" alt="before" src="https://github.com/user-attachments/assets/7dc8bbea-96ac-4313-b02b-eb1b5eac75e3" /> | <img width="1920" height="1080" alt="after" src="https://github.com/user-attachments/assets/de6baa47-9816-47f8-bff0-4f22000a5412" /> |
