### PR TITLE
Port some fps fixes from IV's FusionFix

### DIFF
--- a/source/comvars.ixx
+++ b/source/comvars.ixx
@@ -181,23 +181,29 @@ export bool IsKeyboardKeyPressed(int vkeycode, int type = 1, const char* hint = 
     }
 }
 
+export class CTimer
+{
+public:
+    static inline GameRef<float> fTimeStep;
+};
+
 class Common
 {
 public:
     Common()
     {
-        FusionFix::onInitEvent() += []()
-        {
-            auto pattern = hook::pattern("53 8B 59 04 85 DB");
-            if (!pattern.empty())
-                getNativeAddress = pattern.get_one().get<void* (__fastcall)(uintptr_t*, uint32_t, uint32_t)>(0);
+        auto pattern = hook::pattern("53 8B 59 04 85 DB");
+        if (!pattern.empty())
+            getNativeAddress = pattern.get_one().get<void* (__fastcall)(uintptr_t*, uint32_t, uint32_t)>(0);
 
-            pattern = hook::pattern("B9 ? ? ? ? E8 ? ? ? ? 85 C0 75 07");
-            nativeHandlerPtrAddress = *pattern.get_first<uintptr_t*>(1);
+        pattern = hook::pattern("B9 ? ? ? ? E8 ? ? ? ? 85 C0 75 07");
+        nativeHandlerPtrAddress = *pattern.get_first<uintptr_t*>(1);
 
-            pattern = hook::pattern("B9 ? ? ? ? E8 ? ? ? ? 84 C0 74 ? E8 ? ? ? ? 2B 86");
-            KeyboardBuffer = *pattern.get_first<void**>(1);
-            pIsKeyboardKeyPressed = (decltype(pIsKeyboardKeyPressed))injector::GetBranchDestination(pattern.get_first(5)).as_int();
-        };
+        pattern = hook::pattern("B9 ? ? ? ? E8 ? ? ? ? 84 C0 74 ? E8 ? ? ? ? 2B 86");
+        KeyboardBuffer = *pattern.get_first<void**>(1);
+        pIsKeyboardKeyPressed = (decltype(pIsKeyboardKeyPressed))injector::GetBranchDestination(pattern.get_first(5)).as_int();
+
+        pattern = hook::pattern("F3 0F 11 05 ? ? ? ? 0F 28 DA");
+        CTimer::fTimeStep.SetAddress(*pattern.get_first<float*>(4));
     }
 } Common;

--- a/source/comvars.ixx
+++ b/source/comvars.ixx
@@ -203,7 +203,7 @@ public:
         KeyboardBuffer = *pattern.get_first<void**>(1);
         pIsKeyboardKeyPressed = (decltype(pIsKeyboardKeyPressed))injector::GetBranchDestination(pattern.get_first(5)).as_int();
 
-        pattern = hook::pattern("F3 0F 11 05 ? ? ? ? 0F 28 DA");
+        pattern = hook::pattern("F3 0F 59 0D ? ? ? ? F3 0F 5C D1 F3 0F 11 96 ? ? ? ? F3 0F 59 05");
         CTimer::fTimeStep.SetAddress(*pattern.get_first<float*>(4));
     }
 } Common;

--- a/source/frameratevigilante.ixx
+++ b/source/frameratevigilante.ixx
@@ -36,7 +36,8 @@ public:
                 CWater::shAddToDynamicWaterSpeed = safetyhook::create_inline(pattern.get_first(0), CWater::AddToDynamicWaterSpeed);
 
                 // Buoyancy (Affects everything floating on any body of water that is flagged as physical)
-                pattern = hook::pattern("8B 44 24 ? 99 2B C2 D1 F8 05 ? ? ? ? 8B C8 81 E1 ? ? ? ? 79 ? 49 83 C9 ? 41 8B 44 24 ? 99 2B C2 D1 F8 05 ? ? ? ? 25 ? ? ? ? 79 ? 48 83 C8 ? 40 0F 57 C0");
+                pattern = find_pattern("8B 44 24 ? 99 2B C2 D1 F8 05 ? ? ? ? 8B C8 81 E1 ? ? ? ? 79 ? 49 83 C9 ? 41 8B 44 24 ? 99 2B C2 D1 F8 05 ? ? ? ? 25 ? ? ? ? 79 ? 48 83 C8 ? 40 0F 57 C0",
+                                       "8B 44 24 ? 99 2B C2 D1 F8 05 ? ? ? ? 8B C8 81 E1 ? ? ? ? 79 ? 49 83 C9 ? 41 8B 44 24 ? 99 2B C2 D1 F8 05 ? ? ? ? 25 ? ? ? ? 79 ? 48 83 C8 ? 40 0F 57 C9");
                 CWater::shModifyDynamicWaterSpeed = safetyhook::create_inline(pattern.get_first(0), CWater::ModifyDynamicWaterSpeed);
 
                 // Helicopter downwash wind particles

--- a/source/frameratevigilante.ixx
+++ b/source/frameratevigilante.ixx
@@ -1,0 +1,71 @@
+module;
+
+#include <common.hxx>
+
+export module frameratevigilante;
+
+import common;
+import comvars;
+
+namespace CWater
+{
+    SafetyHookInline shAddToDynamicWaterSpeed = {};
+    void __cdecl AddToDynamicWaterSpeed(int a1, int a2, float a3)
+    {
+        return shAddToDynamicWaterSpeed.unsafe_ccall(a1, a2, a3 * (CTimer::fTimeStep / (1.0f / 30.0f)));
+    }
+
+    SafetyHookInline shModifyDynamicWaterSpeed = {};
+    void __cdecl ModifyDynamicWaterSpeed(int a1, int a2, float a3, float a4)
+    {
+        return shModifyDynamicWaterSpeed.unsafe_ccall(a1, a2, a3, a4 * (CTimer::fTimeStep / (1.0f / 30.0f)));
+    }
+}
+
+class FramerateVigilante
+{
+public:
+	FramerateVigilante()
+	{
+		FusionFix::onInitEventAsync() += []()
+		{
+            // Fix water physics and effects
+            {
+                // Helicopter downwash force
+                auto pattern = hook::pattern("8B 44 24 ? 99 2B C2 D1 F8 05 ? ? ? ? 8B C8 81 E1 ? ? ? ? 79 ? 49 83 C9 ? 41 8B 44 24 ? 99 2B C2 D1 F8 05 ? ? ? ? 25 ? ? ? ? 79 ? 48 83 C8 ? 40 F3 0F 10 0D");
+                CWater::shAddToDynamicWaterSpeed = safetyhook::create_inline(pattern.get_first(0), CWater::AddToDynamicWaterSpeed);
+
+                // Buoyancy (Affects everything floating on any body of water that is flagged as physical)
+                pattern = hook::pattern("8B 44 24 ? 99 2B C2 D1 F8 05 ? ? ? ? 8B C8 81 E1 ? ? ? ? 79 ? 49 83 C9 ? 41 8B 44 24 ? 99 2B C2 D1 F8 05 ? ? ? ? 25 ? ? ? ? 79 ? 48 83 C8 ? 40 0F 57 C0");
+                CWater::shModifyDynamicWaterSpeed = safetyhook::create_inline(pattern.get_first(0), CWater::ModifyDynamicWaterSpeed);
+
+                // Helicopter downwash wind particles
+                pattern = hook::pattern("F7 F1 85 D2 75 ? D9 EE");
+                static auto CVehicleFx__UpdateFxHeliDownwash_Hook = safetyhook::create_mid(pattern.get_first(0), [](SafetyHookContext& regs)
+                {
+                    float f = std::min(CTimer::fTimeStep / (1.0f / 30.0f), 1.0f);
+
+                    regs.ecx = std::max((int)((float)regs.ecx / f), 1);
+                });
+
+                // Boat ripple particles
+                pattern = hook::pattern("F7 F6 85 D2");
+                static auto CWaterFx__RegisterWakePoint_Hook = safetyhook::create_mid(pattern.get_first(0), [](SafetyHookContext& regs)
+                {
+                    float f = std::min(CTimer::fTimeStep / (1.0f / 30.0f), 1.0f);
+
+                    regs.esi = std::max((int)((float)regs.esi / f), 1);
+                });
+
+                // Swim ripple particles
+                pattern = hook::pattern("F7 F1 85 D2 0F 85 ? ? ? ? 8B 55");
+                static auto CBuoyancy__ProcessSplashVfx_Hook = safetyhook::create_mid(pattern.get_first(0), [](SafetyHookContext& regs)
+                {
+                    float f = std::min(CTimer::fTimeStep / (1.0f / 30.0f), 1.0f);
+
+                    regs.ecx = std::max((int)((float)regs.ecx / f), 1);
+                });
+            }
+		};
+	}
+} FramerateVigilante;


### PR DESCRIPTION
This pr ports the[ water physics/effects' fps fixes](https://github.com/ThirteenAG/GTAIV.EFLC.FusionFix/blob/9b8d41d66723c721476d7c4a3c2d738e6f439553/source/frameratevigilante.ixx#L781) from IV's FusionFix. Not much more to say other that it also fixes the gradual performance tanking the unscaled effects had, as they had in IV, although it will be less noticeable here due to the port being more optimized in general in other areas.